### PR TITLE
Alteração da classe "side-bar-box header"

### DIFF
--- a/assets/css/estilos.css
+++ b/assets/css/estilos.css
@@ -2444,7 +2444,7 @@ nav.pager ul.pager__items li.is-active a {
   width: 100%;
   padding: 20px;
   background-color: #086AAB;
-  background-image: url(../img/icon-sub.png);
+  /*background-image: url(../img/icon-sub.png);*/
   background-position: right 20px center;
   background-repeat: no-repeat;
   color: #ffffff;


### PR DESCRIPTION
Alteração da classe "side-bar-box header" no arquivo "estilos.css". 
A linha 2447 foi comentada para não mostrar os botões de minimização no menú de navegação lateral direito em Notícias e CEM na mídia no website do CEM.